### PR TITLE
[a-DUY] feat: tạo comment trong ConnectionStrings để có thể chạy cho …

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -8,6 +8,7 @@
   "AllowedHosts": "*",
 
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost,1433;Database=Zela;User ID=sa;Password=123456;MultipleActiveResultSets=true;Encrypt=True;TrustServerCertificate=True;"
+    "_Comment": "Server=localhost,1433;Database=Zela;User ID=sa;Password=123456;MultipleActiveResultSets=true;Encrypt=True;TrustServerCertificate=True;",
+    "DefaultConnection": "Server=localhost,57000;Database=Zela;User ID=SA;Password=Str#ng_Passw#rd;MultipleActiveResultSets=true;Encrypt=True;TrustServerCertificate=True;"
   }
 }


### PR DESCRIPTION
"ConnectionStrings": {
    "_Comment": "Server=localhost,1433;Database=Zela;User ID=sa;Password=123456;MultipleActiveResultSets=true;Encrypt=True;TrustServerCertificate=True;",
    "DefaultConnection": "Server=localhost,57000;Database=Zela;User ID=SA;Password=Str#ng_Passw#rd;MultipleActiveResultSets=true;Encrypt=True;TrustServerCertificate=True;"
  }
  làm ra cái này để có thể chạy cho cả mac vad wins có database